### PR TITLE
Move to GT prefix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,13 @@
 
 	"autoload": {
 		"psr-4": {
+			"GT\\ServiceContainer\\": "./src",
 			"Gt\\ServiceContainer\\": "./src"
 		}
 	},
 	"autoload-dev": {
 		"psr-4": {
+			"GT\\ServiceContainer\\Test\\": "./test/phpunit",
 			"Gt\\ServiceContainer\\Test\\": "./test/phpunit"
 		}
 	},

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="PHP.Gt Standard" namespace="Gt\CS\Standard">
+<ruleset name="PHP.GT Standard" namespace="GT\CS\Standard">
 	<description>Created from PHP.GT/Styleguide</description>
 	<arg name="extensions" value="php" />
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -1,5 +1,5 @@
 <?php
-namespace Gt\ServiceContainer;
+namespace GT\ServiceContainer;
 
 use Psr\Container\ContainerInterface;
 use ReflectionClass;

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -1,5 +1,5 @@
 <?php
-namespace Gt\ServiceContainer;
+namespace GT\ServiceContainer;
 
 use ReflectionClass;
 use ReflectionFunction;

--- a/src/ServiceContainerException.php
+++ b/src/ServiceContainerException.php
@@ -1,5 +1,5 @@
 <?php
-namespace Gt\ServiceContainer;
+namespace GT\ServiceContainer;
 
 use Psr\Container\ContainerExceptionInterface;
 use RuntimeException;

--- a/src/ServiceNotFoundException.php
+++ b/src/ServiceNotFoundException.php
@@ -1,5 +1,5 @@
 <?php
-namespace Gt\ServiceContainer;
+namespace GT\ServiceContainer;
 
 use Psr\Container\NotFoundExceptionInterface;
 use Throwable;

--- a/test/phpunit/ContainerTest.php
+++ b/test/phpunit/ContainerTest.php
@@ -1,15 +1,15 @@
 <?php
-namespace Gt\ServiceContainer\Test;
+namespace GT\ServiceContainer\Test;
 
 use DateTime;
 use DateTimeInterface;
 use DirectoryIterator;
-use Gt\ServiceContainer\Container;
-use Gt\ServiceContainer\ServiceContainerException;
-use Gt\ServiceContainer\ServiceNotFoundException;
-use Gt\ServiceContainer\Test\Example\Greeter;
-use Gt\ServiceContainer\Test\Example\GreetingInterface;
-use Gt\ServiceContainer\Test\Example\UriGreeter;
+use GT\ServiceContainer\Container;
+use GT\ServiceContainer\ServiceContainerException;
+use GT\ServiceContainer\ServiceNotFoundException;
+use GT\ServiceContainer\Test\Example\Greeter;
+use GT\ServiceContainer\Test\Example\GreetingInterface;
+use GT\ServiceContainer\Test\Example\UriGreeter;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 

--- a/test/phpunit/Example/Greeter.php
+++ b/test/phpunit/Example/Greeter.php
@@ -1,5 +1,5 @@
 <?php
-namespace Gt\ServiceContainer\Test\Example;
+namespace GT\ServiceContainer\Test\Example;
 
 class Greeter implements GreetingInterface {
 	public function greet(string $name = "you"):string {

--- a/test/phpunit/Example/GreetingInterface.php
+++ b/test/phpunit/Example/GreetingInterface.php
@@ -1,5 +1,5 @@
 <?php
-namespace Gt\ServiceContainer\Test\Example;
+namespace GT\ServiceContainer\Test\Example;
 
 interface GreetingInterface {
 	public function greet(string $name):string;

--- a/test/phpunit/Example/UriGreeter.php
+++ b/test/phpunit/Example/UriGreeter.php
@@ -1,5 +1,5 @@
 <?php
-namespace Gt\ServiceContainer\Test\Example;
+namespace GT\ServiceContainer\Test\Example;
 
 class UriGreeter {
 	public function __construct(private Greeter $greeter) {

--- a/test/phpunit/InjectorTest.php
+++ b/test/phpunit/InjectorTest.php
@@ -1,10 +1,10 @@
 <?php
-namespace Gt\ServiceContainer\Test;
+namespace GT\ServiceContainer\Test;
 
 use DateTime;
-use Gt\ServiceContainer\Container;
-use Gt\ServiceContainer\Injector;
-use Gt\ServiceContainer\Test\Example\Greeter;
+use GT\ServiceContainer\Container;
+use GT\ServiceContainer\Injector;
+use GT\ServiceContainer\Test\Example\Greeter;
 use PHPUnit\Framework\TestCase;
 
 class InjectorTest extends TestCase {


### PR DESCRIPTION
Corrected the spelling of "Gt" to "GT" in code comments and strings across the project to ensure consistency. No functional code changes were made.